### PR TITLE
fix typo in sql queries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MpiIsoData
 Type: Package
 Title: Data for MPI Iso App
-Version: 23.03.2.1
+Version: 23.03.2.2
 Author: INWT Statistics GmbH
 Maintainer: INWT Statistics GmbH <info@inwt-statistics.de>
 Description: This package provides access to databases to use in the

--- a/R/03-updateMapping.R
+++ b/R/03-updateMapping.R
@@ -12,7 +12,7 @@ etlMapping <- function(){
 
     mappingTable <- cbind(mappingId = mappingName, mappingTable)
 
-    sendQueryMPI("deleteOldMapping", mappingId = mappingName)
+    sendQueryMPI("deleteOldMapping", mappingId = dbtools::sqlEsc(mappingName, with = "'"))
     sendDataMPI(mappingTable, table = "mapping", mode = "insert")
   }
   ## mappingSource <- mappingTable %>%

--- a/inst/sql/deleteOldData.sql
+++ b/inst/sql/deleteOldData.sql
@@ -1,1 +1,1 @@
-DELETE FROM `{{ tableName }}` WHERE `mappingId` = `{{ mappingId }}` AND `source` = `{{ dbSource }}`;
+DELETE FROM {{ tableName }} WHERE `mappingId` = {{ mappingId }} AND `source` = {{ dbSource }};

--- a/inst/sql/deleteOldMapping.sql
+++ b/inst/sql/deleteOldMapping.sql
@@ -1,1 +1,1 @@
-DELETE FROM `mapping` WHERE `mappingId` = `{{ mappingId }}`;
+DELETE FROM `mapping` WHERE `mappingId` = {{ mappingId }};

--- a/inst/sql/mappingId_data.sql
+++ b/inst/sql/mappingId_data.sql
@@ -1,3 +1,6 @@
-CREATE TABLE IF NOT EXISTS `{{ tableName }}` ({{ colDefs }}, PRIMARY KEY (`source`,`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+CREATE TABLE IF NOT EXISTS {{ tableName }} (
+  {{ colDefs }},
+  PRIMARY KEY (`source`, `id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-DELETE FROM `{{ tableName }}` WHERE `source` = `{{ dbSource }}`;
+DELETE FROM {{ tableName }} WHERE `source` = {{ dbSource }};


### PR DESCRIPTION
- fix regarding [error](https://isomemodb.com/jenkins/job/mpi-iso-etl-test/273/console):
```
ERROR [2023-09-03 01:16:08] Error in .local(conn, statement, ...) : 
could not run statement: You have an error in your SQL syntax; ...
```
@jan-abel-inwt This could explain why the job did fail in the past. Please, let us try this fix when you have time again.